### PR TITLE
Fix for multiple gamepads sending input

### DIFF
--- a/src/Driver/Gamepad.ts
+++ b/src/Driver/Gamepad.ts
@@ -25,7 +25,7 @@ export default class GamepadDriver {
 
     requestState() {
         const gamepads = navigator.getGamepads()
-		
+		let foundActive = false
         for(let gamepad = 0; gamepad < gamepads.length; gamepad++){
             const gamepadState = gamepads[gamepad]
 			
@@ -40,13 +40,19 @@ export default class GamepadDriver {
 				
 				//Queue state of the active gamepad
 				if(gamepadState.index == this._activeGamepadIndex){
+					foundActive = true
 					const state = this.mapStateLabels(gamepadState.buttons, gamepadState.axes)
 					state.GamepadIndex = 0 // @TODO: Could we use a second gamepad this way?
 					this._application?.getChannelProcessor('input').queueGamepadState(state)
+					break;
 				}
-				
 			}
         }
+		
+		//If gamepad is no longer connected, then clear active index
+		if(!foundActive){
+			this._activeGamepadIndex = -1;
+		}
     }
 
     mapStateLabels(buttons, axes) {

--- a/src/Driver/Gamepad.ts
+++ b/src/Driver/Gamepad.ts
@@ -6,6 +6,7 @@ export default class GamepadDriver {
     _application:xCloudPlayer|null = null
 
     _gamepads:Array<any> = []
+	_activeGamepadIndex = -1;
 
     // constructor() {
     // }
@@ -24,15 +25,27 @@ export default class GamepadDriver {
 
     requestState() {
         const gamepads = navigator.getGamepads()
+		
         for(let gamepad = 0; gamepad < gamepads.length; gamepad++){
             const gamepadState = gamepads[gamepad]
-            
-            if(gamepadState !== null){
-                const state = this.mapStateLabels(gamepadState.buttons, gamepadState.axes)
-                state.GamepadIndex = 0 // @TODO: Could we use a second gamepad this way?
-
-                this._application?.getChannelProcessor('input').queueGamepadState(state)
-            }
+			
+			if(gamepadState != null && gamepadState.connected){
+				//We need to find the active gamepad
+				if(this._activeGamepadIndex == -1){
+					//This gamepad has a button pressed, make it the active gamepad
+					if(gamepadState.buttons.some(b => b.value >= .75)){
+						this._activeGamepadIndex = gamepadState.index
+					}
+				}
+				
+				//Queue state of the active gamepad
+				if(gamepadState.index == this._activeGamepadIndex){
+					const state = this.mapStateLabels(gamepadState.buttons, gamepadState.axes)
+					state.GamepadIndex = 0 // @TODO: Could we use a second gamepad this way?
+					this._application?.getChannelProcessor('input').queueGamepadState(state)
+				}
+				
+			}
         }
     }
 

--- a/src/Driver/Gamepad.ts
+++ b/src/Driver/Gamepad.ts
@@ -3,15 +3,15 @@ import { InputFrame } from '../Channel/Input'
 
 export default class GamepadDriver {
 
-    _application:xCloudPlayer|null = null
+    _application: xCloudPlayer | null = null
 
-    _gamepads:Array<any> = []
-	_activeGamepadIndex = -1;
+    _gamepads: Array<any> = []
+    _activeGamepadIndex = -1;
 
     // constructor() {
     // }
 
-    setApplication(application:xCloudPlayer) {
+    setApplication(application: xCloudPlayer) {
         this._application = application
     }
 
@@ -25,34 +25,34 @@ export default class GamepadDriver {
 
     requestState() {
         const gamepads = navigator.getGamepads()
-		let foundActive = false
-        for(let gamepad = 0; gamepad < gamepads.length; gamepad++){
+        let foundActive = false
+        for (let gamepad = 0; gamepad < gamepads.length; gamepad++) {
             const gamepadState = gamepads[gamepad]
-			
-			if(gamepadState != null && gamepadState.connected){
-				//We need to find the active gamepad
-				if(this._activeGamepadIndex == -1){
-					//This gamepad has a button pressed, make it the active gamepad
-					if(gamepadState.buttons.some(b => b.value >= .75)){
-						this._activeGamepadIndex = gamepadState.index
-					}
-				}
-				
-				//Queue state of the active gamepad
-				if(gamepadState.index == this._activeGamepadIndex){
-					foundActive = true
-					const state = this.mapStateLabels(gamepadState.buttons, gamepadState.axes)
-					state.GamepadIndex = 0 // @TODO: Could we use a second gamepad this way?
-					this._application?.getChannelProcessor('input').queueGamepadState(state)
-					break;
-				}
-			}
+
+            if (gamepadState != null && gamepadState.connected) {
+                //We need to find the active gamepad
+                if (this._activeGamepadIndex == -1) {
+                    //This gamepad has a button pressed, make it the active gamepad
+                    if (gamepadState.buttons.some(b => b.value >= .75)) {
+                        this._activeGamepadIndex = gamepadState.index
+                    }
+                }
+
+                //Queue state of the active gamepad
+                if (gamepadState.index == this._activeGamepadIndex) {
+                    foundActive = true
+                    const state = this.mapStateLabels(gamepadState.buttons, gamepadState.axes)
+                    state.GamepadIndex = 0 // @TODO: Could we use a second gamepad this way?
+                    this._application?.getChannelProcessor('input').queueGamepadState(state)
+                    break;
+                }
+            }
         }
-		
-		//If gamepad is no longer connected, then clear active index
-		if(!foundActive){
-			this._activeGamepadIndex = -1;
-		}
+
+        //If gamepad is no longer connected, then clear active index
+        if (!foundActive) {
+            this._activeGamepadIndex = -1;
+        }
     }
 
     mapStateLabels(buttons, axes) {


### PR DESCRIPTION
Handle the case of multiple controllers. This specifically occurs on the steam deck if you are using an external controller, because steam input creates 2nd virtual gamepad, which was causing issues with the old implementation.